### PR TITLE
implement recommendations from PR review https://www.drupal.org/node/…

### DIFF
--- a/modules/product/src/Entity/ProductVariation.php
+++ b/modules/product/src/Entity/ProductVariation.php
@@ -59,7 +59,7 @@ class ProductVariation extends ContentEntityBase implements ProductVariationInte
       // Set our variation id as query string.
       $options = [
         'query' => [
-          'dv' => $this->id(),
+          self::CANONICAL_QUERY_PARAM => $this->id(),
         ],
       ];
 

--- a/modules/product/src/Entity/ProductVariationInterface.php
+++ b/modules/product/src/Entity/ProductVariationInterface.php
@@ -12,6 +12,11 @@ use Drupal\user\EntityOwnerInterface;
 interface ProductVariationInterface extends PurchasableEntityInterface, EntityChangedInterface, EntityOwnerInterface {
 
   /**
+   * Query string parameter name for defining a canonical URL to a product variation.
+   */
+  const CANONICAL_QUERY_PARAM = 'dv';
+
+  /**
    * Gets the parent product.
    *
    * @return ProductInterface|null


### PR DESCRIPTION
…2674888#comment-10987951

Hi Rob,
I've implemented the recommendations from Matt (https://www.drupal.org/node/2674888#comment-10987951). All changes SHOULD work, I didn't have time to run the code.

Your PR is not in sync with the master branch at the moment - also didn't have time to sync your changes with master before. However it should be a better help for you rather than only writing a comment...

I've put the CANONICAL_QUERY_PARAM constant into the ProductVariationInterface. However I'm not happy with that either. This is cleaner than just the string and makes it easier to replace, however it's still unflexible. What do you think about adding a (static) function, that returns 'dv' just for now. So there won't be an API change, when e.g. a configuration will be introduced in future, or an alter hook..
